### PR TITLE
Webhooks fix

### DIFF
--- a/docker/.env-example
+++ b/docker/.env-example
@@ -1,7 +1,7 @@
 COMPOSE_PROJECT_NAME=combinary-collector-facebook
 APP_ID=*available from app account*
 APP_SECRET=*available from app account*
-GRAPH_VERSION=v3.2
+GRAPH_VERSION=v5.0
 ENDPOINT_ACCESS_TOKEN=*APP_ID*|*APP_SECRET*
 VERIFY_TOKEN=*made up token set in facebook developer site for webhooks*
 

--- a/docroot/Db.php
+++ b/docroot/Db.php
@@ -35,6 +35,12 @@ class Db
         }
     }
 
+    public function Update($tableName, $array, $conditions)
+    {
+        $res = pg_update($this->Connect(), $tableName, $array, $conditions);
+        return $res;
+    }
+
     public function Remove($tableName, $array)
     {
         $res = pg_delete($this->Connect(), $tableName, $array);

--- a/docroot/Db.php
+++ b/docroot/Db.php
@@ -161,7 +161,7 @@ class Db
         $postArray = [
             "id" => $post->id,
             "page_id" => $pageId,
-            "type" => $post->type,
+            "type" => $post->status_type,
             "created_time" => $post->created_time,
             "story" => $post->story,
             "message" => $post->message

--- a/docroot/fb_helper.php
+++ b/docroot/fb_helper.php
@@ -16,8 +16,8 @@ class fb_helper
 
     function SavePostsOnPage($pageId)
     {
-        $query = '/' . $pageId . '/feed/?fields=message,story,link,created_time,type,name,id,comments{from,message,like_count,comment_count,created_time,comments{from,like_count,comment_count,message,created_time}},attachments,likes,reactions';
-        
+        $query = '/' . $pageId . '/feed/?fields=message,story,created_time,status_type,id,comments{from,message,like_count,comment_count,created_time,comments{from,like_count,comment_count,message,created_time}},attachments,likes,reactions';
+
         try{
         $response = $this->facebook->fb->get($query, $this->facebook->GetAccessToken());
 

--- a/docroot/monitor.php
+++ b/docroot/monitor.php
@@ -138,7 +138,7 @@ $page_list = [];
         if (!$facebook->WebhookStatus($pageArray[0])) {
             $facebook->SubscribeToWebhooks($pageArray[0]);
         }
-        $facebook->SubscribeAppToWebhooks();
+        //$facebook->SubscribeAppToWebhooks();
         ?>
         <script>
             ChangeCheckbox("<?php echo $pageArray[0] ?>")

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -60,27 +60,39 @@ class webhook_helper
         }
         
         if ($data->value->item === "comment") {
-            $commentIdArray = $this->ExplodeId($data->value->comment_id);
 
+                $commentIdArray = $this->ExplodeId($data->value->comment_id);
+                $feedId = $idArray[1];
+                $commentId = $commentIdArray[1];
 
-            $feedId = $idArray[1];
+                if ($data->value->verb === "add") {
 
-            $commentId = $commentIdArray[1];
-            $from = [
-                "id" => $data->from->id,
-                "name" => $data->from->name
-            ];
+                        $comment = [
+                                "created_time" => [
+                                        "date" => $this->ConvertUnixTime($data->value->created_time)
+                                ],
+                                "message" => $data->value->message,
+                                "comment_count" => 0,
+                                "like_count" => 0,
+                                "from" => [
+                                        "id" => $data->value->from->id,
+                                        "name" => $data->value->from->name
+                                ]
+                        ];
 
-            $comment = [
-                "created_time" => $this->ConvertUnixTime($json_obj->entry[0]->time),
-                "message" => $data->message,
-                "comment_count" => 0,
-                "like_count" => 0,
-                "from" => $from
-            ];
+                        $comment = json_decode(json_encode($comment));
+                        $this->database->SaveCommentData($page_id, $commentId, $comment, $feedId);
 
-            $this->database->SaveCommentData($page_id, $commentId, $comment, $feedId);
-            return;
+                } elseif ($data->value->verb === "remove") {
+
+                        $removeArray = [
+                                "id" => $commentId
+                        ];
+                        $this->database->Remove("comment", $removeArray);
+
+                }
+
+                return;
         }
 
         if ($data->value->item === "reaction") {

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -83,6 +83,19 @@ class webhook_helper
                         $comment = json_decode(json_encode($comment));
                         $this->database->SaveCommentData($page_id, $commentId, $comment, $feedId);
 
+                } elseif ($data->value->verb === "edited") {
+
+                        $condition = [
+                            "id" => $commentId
+                        ];
+
+                        $newcomment = [
+                            "message" => $data->value->message
+                        ];
+
+                        $this->database->Update("comment", $newcomment, $condition);
+
+
                 } elseif ($data->value->verb === "remove") {
 
                         $removeArray = [

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -35,17 +35,34 @@ class webhook_helper
 
         if ( $data->value->item === "status" ) {
 
-                $postArray = [
-                        'id' => $idArray[1],
-                        'page_id' => $idArray[0],
-                        'type' => $data->value->item,
-                        'created_time' => $this->ConvertUnixTime($data->value->created_time),
-                        'story' => '',
-                        'message' => $data->value->message
-                ];
+                if ($data->value->verb === "add") {
 
-                $post = (object) $postArray;
-                $this->database->SavePostData( $post, $post->page_id );
+                    $postArray = [
+                            'id' => $idArray[1],
+                            'page_id' => $idArray[0],
+                            'type' => $data->value->item,
+                            'created_time' => $this->ConvertUnixTime($data->value->created_time),
+                            'story' => '',
+                            'message' => $data->value->message
+                    ];
+
+                    $post = (object) $postArray;
+                    $this->database->SavePostData( $post, $post->page_id );
+
+                } elseif($data->value->verb === "edited") {
+
+                    $condition = [
+                        'id' => $idArray[1]
+                    ];
+
+                    $newstatus = [
+                        'message' => $data->value->message
+                    ];
+
+                    $this->database->Update("post", $newstatus, $condition);
+
+                }
+
                 return;
         }
 
@@ -94,7 +111,6 @@ class webhook_helper
                         ];
 
                         $this->database->Update("comment", $newcomment, $condition);
-
 
                 } elseif ($data->value->verb === "remove") {
 

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -40,7 +40,7 @@ class webhook_helper
                     $postArray = [
                             'id' => $idArray[1],
                             'page_id' => $idArray[0],
-                            'type' => $data->value->item,
+                            'status_type' => $data->value->item,
                             'created_time' => $this->ConvertUnixTime($data->value->created_time),
                             'story' => '',
                             'message' => $data->value->message
@@ -69,6 +69,7 @@ class webhook_helper
                                 ];
 
                                 $attach = json_decode(json_encode($attachArray));
+
                                 $this->database->SaveAttachmentData($idArray[0],$idArray[1],$attach);
                         }
 
@@ -171,7 +172,7 @@ class webhook_helper
                     $postArray = [
                         'id' => $data->value->album_id,
                         'page_id' => $data->value->from->id,
-                        'type' => $data->value->item,
+                        'status_type' => $data->value->item,
                         'created_time' => $this->ConvertUnixTime($data->value->created_time),
                         'story' => '',
                         'message' => ''

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -49,6 +49,16 @@ class webhook_helper
                 return;
         }
 
+        if ( $data->value->item === "post" ) {
+                if ( $data->value->verb === "remove" ) {
+                        $removeArray = [
+                                "id" => $idArray[1]
+                        ];
+                }
+                $this->database->Remove("post", $removeArray);
+                return;
+        }
+        
         if ($data->value->item === "comment") {
             $commentIdArray = $this->ExplodeId($data->value->comment_id);
 

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -33,7 +33,7 @@ class webhook_helper
             dbg(['value->item'=>$data->value->item]);
         }
 
-        if ( $data->value->item === "status" ) {
+        if ( in_array( $data->value->item, array("status","share","photo","video") ) ) {
 
                 if ($data->value->verb === "add") {
 

--- a/docroot/webhook_helper.php
+++ b/docroot/webhook_helper.php
@@ -33,6 +33,22 @@ class webhook_helper
             dbg(['value->item'=>$data->value->item]);
         }
 
+        if ( $data->value->item === "status" ) {
+
+                $postArray = [
+                        'id' => $idArray[1],
+                        'page_id' => $idArray[0],
+                        'type' => $data->value->item,
+                        'created_time' => $this->ConvertUnixTime($data->value->created_time),
+                        'story' => '',
+                        'message' => $data->value->message
+                ];
+
+                $post = (object) $postArray;
+                $this->database->SavePostData( $post, $post->page_id );
+                return;
+        }
+
         if ($data->value->item === "comment") {
             $commentIdArray = $this->ExplodeId($data->value->comment_id);
 
@@ -90,7 +106,7 @@ class webhook_helper
 
     function ConvertUnixTime($unixTime)
     {
-        return date('Y-m-d h:i:s', $unixTime);
+        return date("c", $unixTime);
     }
 
     function ExplodeId($id)


### PR DESCRIPTION
I have tried to do a fix by editing `webhook_helper.php` only, and avoid to change `Db.php` (because of 'Import data from page' functions).

So these webhook actions are now accepted & saved:
- the new post is added - a new entry is added to the database table 'post'
- the post is deleted - entry is deleted from the database table 'post'
- the new comment is added - a new entry is added to the database table 'comment'
- the comment is deleted - entry is deleted from the database table 'comment'

Looks like these worked fine before:
- the new reaction happened (eg. like) - a new entry is added to the database 'reaction'
- the reaction is removed (eg. un-like) - entry is deleted from the database 'reaction'

TODO:
- [x] the post is edited - make entry updated in the database table 'post'
- [x] the comment is edited - make entry updated in the database table 'comment'

Please note, subscription should be enabled for 'feed' in the FB App - Webhooks settings:

<img width="873" alt="Screen Shot 2020-01-17 at 12 22 52 PM" src="https://user-images.githubusercontent.com/18518676/72608958-245e7f00-3924-11ea-8832-a5e075422d0b.png">

TODO (UPDATE 19.01 - Configured correctly and looks like it works fine already):
- [x] make working Subscribe on webhooks button
- [x] make working Unsubscribe from webhooks button

TODO (17.01)
- [x] add webhook functions to save a post attachments
